### PR TITLE
Fix canvas clearing on resize

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -21,8 +21,22 @@ const Whiteboard = ({ roomId }: WhiteboardProps) => {
     if (!ctx) return;
 
     const handleResize = () => {
+      // Preserve current drawing before resizing because changing the canvas
+      // size clears its contents.
+      const prevCanvas = document.createElement('canvas');
+      prevCanvas.width = canvas.width;
+      prevCanvas.height = canvas.height;
+      const prevCtx = prevCanvas.getContext('2d');
+      if (prevCtx) {
+        prevCtx.drawImage(canvas, 0, 0);
+      }
+
       canvas.width = canvas.offsetWidth;
       canvas.height = canvas.offsetHeight;
+
+      if (prevCtx) {
+        ctx.drawImage(prevCanvas, 0, 0, prevCanvas.width, prevCanvas.height);
+      }
     };
     handleResize();
     window.addEventListener('resize', handleResize);


### PR DESCRIPTION
## Summary
- preserve canvas contents when window resizes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c7b9db05c83269d77b48ee0e05957